### PR TITLE
feat : 지수 데이터 목록 조회 N+1 문제 해결 (fetch join)

### DIFF
--- a/findex/src/main/java/com/example/findex/domain/Index_data/repository/impl/IndexDataRepositoryImpl.java
+++ b/findex/src/main/java/com/example/findex/domain/Index_data/repository/impl/IndexDataRepositoryImpl.java
@@ -15,6 +15,7 @@ import java.time.LocalDate;
 import java.util.Base64;
 import java.util.List;
 
+import static com.example.findex.domain.Auto_Sync.entity.QAutoSync.autoSync;
 import static com.example.findex.domain.Index_data.entity.QIndexData.indexData;
 import static com.example.findex.domain.Index_Info.entity.QIndexInfo.indexInfo;
 
@@ -49,6 +50,7 @@ public class IndexDataRepositoryImpl implements IndexDataRepositoryCustom {
         return queryFactory
                 .selectFrom(indexData)
                 .join(indexData.indexInfo, indexInfo).fetchJoin()
+                .leftJoin(indexInfo.autoSync, autoSync).fetchJoin()
                 .where(whereClause)
                 .orderBy(buildOrderSpecifier(sortField, sortDirection))
                 .limit(size + 1)


### PR DESCRIPTION
indexinfo에 autosync 테이블을 N번 조회하는 N+1 문제가 발생해서
이를 fetch join 사용해서 해결했습니다.