### PR TITLE
feat : 대시보드 일간 안되던가 수정 / 지수 정보 페이제네이션 제대로 안되던거 수정 / 지수 정보 총 갯수 구하는것 분…

### DIFF
--- a/findex/src/main/java/com/example/findex/domain/Index_Info/controller/IndexInfoController.java
+++ b/findex/src/main/java/com/example/findex/domain/Index_Info/controller/IndexInfoController.java
@@ -35,7 +35,7 @@ public class IndexInfoController {
   }
   @GetMapping
   public ResponseEntity<CursorPageResponseIndexInfoDto> findAll(
-      @RequestParam(required = false) Long cursor,
+      @RequestParam(required = false) String cursor,
       @RequestParam(defaultValue = "10") int size,
       @RequestParam(required = false) String sortField,
       @RequestParam(required = false) String sortDirection,
@@ -47,7 +47,7 @@ public class IndexInfoController {
 
 
     CursorPageResponseIndexInfoDto response =
-        service.findByCursorAndSortAndFilter(cursor, size, sortField, sortDirection,indexClassification,indexName,favorite);
+        service.findByCursorAndFilter(cursor, size, sortField, sortDirection,indexClassification,indexName,favorite);
 
     return ResponseEntity.ok(response);
   }

--- a/findex/src/main/java/com/example/findex/domain/Index_Info/repository/IndexInfoRepository.java
+++ b/findex/src/main/java/com/example/findex/domain/Index_Info/repository/IndexInfoRepository.java
@@ -1,11 +1,12 @@
 package com.example.findex.domain.Index_Info.repository;
 
 import com.example.findex.domain.Index_Info.entity.IndexInfo;
-import java.util.List;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface IndexInfoRepository extends JpaRepository<IndexInfo, Long>, IndexInfoRepositoryCustom {
@@ -21,5 +22,14 @@ public interface IndexInfoRepository extends JpaRepository<IndexInfo, Long>, Ind
 
     // 정렬 조건을 Pageable로 전달받는 버전 (asc/desc 동적으로 적용 가능)
     List<IndexInfo> findByIdGreaterThan(Long id,Pageable pageable);
+
+    @Query("""
+    select count(i)
+    from IndexInfo i
+    where (:cls = '' or i.indexClassification like concat('%', :cls, '%'))
+      and (:name = '' or i.indexName like concat('%', :name, '%'))
+      and (:fav is null or i.favorite = :fav)
+""")
+    long countByFilter(String cls, String name, Boolean fav);
 
 }

--- a/findex/src/main/java/com/example/findex/domain/Index_Info/repository/IndexInfoRepositoryCustom.java
+++ b/findex/src/main/java/com/example/findex/domain/Index_Info/repository/IndexInfoRepositoryCustom.java
@@ -4,5 +4,5 @@ import com.example.findex.domain.Index_Info.entity.IndexInfo;
 import java.util.List;
 
 public interface IndexInfoRepositoryCustom {
-  List<IndexInfo> findByCursorAndFilter(Long cursor, int size, String sortField, String sortDirection ,String indexClassification, String indexName, Boolean favorite);
+  List<IndexInfo> findByCursorAndFilter(String cursor, int size, String sortField, String sortDirection ,String indexClassification, String indexName, Boolean favorite);
 }

--- a/findex/src/main/java/com/example/findex/domain/Index_data/controller/IndexDataController.java
+++ b/findex/src/main/java/com/example/findex/domain/Index_data/controller/IndexDataController.java
@@ -1,12 +1,6 @@
 package com.example.findex.domain.Index_data.controller;
 
-import com.example.findex.domain.Index_data.dto.CursorPageResponseIndexDataDto;
-import com.example.findex.domain.Index_data.dto.IndexChartResponse;
-import com.example.findex.domain.Index_data.dto.RankedIndexPerformanceDto;
-import com.example.findex.domain.Index_data.dto.IndexDataCreateRequest;
-import com.example.findex.domain.Index_data.dto.IndexDataDto;
-import com.example.findex.domain.Index_data.dto.IndexDataUpdateRequest;
-import com.example.findex.domain.Index_data.dto.PeriodType;
+import com.example.findex.domain.Index_data.dto.*;
 import com.example.findex.domain.Index_data.service.IndexDataService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.format.annotation.DateTimeFormat;
@@ -92,6 +86,13 @@ public class IndexDataController {
             @RequestParam(defaultValue = "DAILY") PeriodType periodType,
             @RequestParam(defaultValue = "10") Integer limit) {
         List<RankedIndexPerformanceDto> responseDto = indexDataService.getRankedPerformance(indexInfoId, periodType, limit);
+        return ResponseEntity.ok(responseDto);
+    }
+
+    @GetMapping("/performance/favorite")
+    public ResponseEntity<List<IndexPerformanceDto>> getFavoritePerformance(
+            @RequestParam(defaultValue = "DAILY") PeriodType periodType) {
+        List<IndexPerformanceDto> responseDto = indexDataService.getFavoritePerformance(periodType);
         return ResponseEntity.ok(responseDto);
     }
 }

--- a/findex/src/main/java/com/example/findex/domain/Index_data/repository/IndexDataRepositoryCustom.java
+++ b/findex/src/main/java/com/example/findex/domain/Index_data/repository/IndexDataRepositoryCustom.java
@@ -1,9 +1,11 @@
+// com/example/findex/domain/Index_data/repository/IndexDataRepositoryCustom.java
 package com.example.findex.domain.Index_data.repository;
 
 import com.example.findex.domain.Index_data.entity.IndexData;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Set;
 
 public interface IndexDataRepositoryCustom {
 
@@ -18,9 +20,9 @@ public interface IndexDataRepositoryCustom {
             Integer size
     );
 
-    List<IndexData> findLatestSnapshotAtOrBefore(LocalDate cutoff, Long indexInfoId);
+    List<IndexData> findLatestSnapshotInRange(LocalDate start, LocalDate end, Set<Long> indexIds);
 
-    List<IndexData> findSnapshotAtExactDate(LocalDate date, Long indexInfoId);
+    List<IndexData> findEarliestSnapshotInRange(LocalDate start, LocalDate end, Set<Long> indexIds);
 
     LocalDate findLatestBaseDate();
 }

--- a/findex/src/main/java/com/example/findex/domain/Index_data/service/IndexDataService.java
+++ b/findex/src/main/java/com/example/findex/domain/Index_data/service/IndexDataService.java
@@ -1,3 +1,4 @@
+// com/example/findex/domain/Index_data/service/IndexDataService.java
 package com.example.findex.domain.Index_data.service;
 
 import com.example.findex.domain.Index_Info.entity.IndexInfo;
@@ -8,8 +9,9 @@ import com.example.findex.domain.Index_data.dto.IndexChartResponse;
 import com.example.findex.domain.Index_data.dto.IndexDataCreateRequest;
 import com.example.findex.domain.Index_data.dto.IndexDataDto;
 import com.example.findex.domain.Index_data.dto.IndexDataUpdateRequest;
+import com.example.findex.domain.Index_data.dto.IndexPerformanceDto;
 import com.example.findex.domain.Index_data.dto.PeriodType;
-import com.example.findex.domain.Index_data.dto.*;
+import com.example.findex.domain.Index_data.dto.RankedIndexPerformanceDto;
 import com.example.findex.domain.Index_data.entity.IndexData;
 import com.example.findex.domain.Index_data.mapper.IndexDataMapper;
 import com.example.findex.domain.Index_data.repository.IndexDataRepository;
@@ -18,13 +20,14 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.function.Function;
-import java.util.stream.Collectors;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.time.LocalDate;
 import java.util.*;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import static java.time.ZoneOffset.UTC;
 
 @Service
 @RequiredArgsConstructor
@@ -38,25 +41,17 @@ public class IndexDataService {
     public IndexDataDto createIndexData(IndexDataCreateRequest request) {
         IndexInfo indexInfo = indexInfoRepository.findById(request.getIndexInfoId())
                 .orElseThrow(() -> new IllegalArgumentException("지수를 찾을 수 없습니다: " + request.getIndexInfoId()));
-
-        if (indexDataRepository.existsByIndexInfoIdAndBaseDate(
-                request.getIndexInfoId(),
-                request.getBaseDate())
-        ) {
+        if (indexDataRepository.existsByIndexInfoIdAndBaseDate(request.getIndexInfoId(), request.getBaseDate())) {
             throw new IllegalArgumentException("해당 지수의 날짜 데이터가 이미 존재합니다: " + request.getBaseDate());
         }
-
         IndexData indexData = indexDataMapper.toEntity(request, indexInfo);
-
         return indexDataMapper.toDto(indexDataRepository.save(indexData));
     }
 
     public IndexDataDto updateIndexData(Long id, IndexDataUpdateRequest request) {
         IndexData indexData = indexDataRepository.findById(id)
                 .orElseThrow(() -> new IllegalArgumentException("지수 데이터를 찾을 수 없습니다: " + id));
-
         indexDataMapper.updateEntityFromRequest(request, indexData);
-
         IndexData saved = indexDataRepository.save(indexData);
         return indexDataMapper.toDto(saved);
     }
@@ -78,8 +73,7 @@ public class IndexDataService {
         String validSortDirection = getValidSortDirection(sortDirection);
 
         List<IndexData> dataList = indexDataRepository.findDataWithDynamicSort(
-                indexInfoId, startDate, endDate,
-                validSortField, validSortDirection, cursor, idAfter, size);
+                indexInfoId, startDate, endDate, validSortField, validSortDirection, cursor, idAfter, size);
 
         boolean hasNext = dataList.size() > size;
         if (hasNext) {
@@ -101,60 +95,16 @@ public class IndexDataService {
         return new CursorPageResponseIndexDataDto(content, nextCursor, nextIdAfter, size, totalElements, hasNext);
     }
 
-    private String getValidSortField(String sortField) {
-        if (sortField == null || sortField.trim().isEmpty()) {
-            return "baseDate";
-        }
-
-        return switch (sortField) {
-            case "baseDate", "closingPrice", "marketPrice", "highPrice", "lowPrice",
-                 "tradingQuantity", "tradingPrice", "marketTotalAmount" -> sortField;
-            default -> "baseDate";
-        };
-    }
-
-    private String getValidSortDirection(String sortDirection) {
-        return "desc".equalsIgnoreCase(sortDirection) ? "desc" : "asc";
-    }
-
-    private String generateNextCursor(IndexData entity, String sortField) {
-        String validatedField = getValidSortField(sortField);
-        Object fieldValue = extractFieldValue(entity, validatedField);
-
-        String json = String.format("{\"%s\":\"%s\",\"id\":%d}",
-                validatedField, fieldValue, entity.getId());
-        return Base64.getEncoder().encodeToString(json.getBytes());
-    }
-
-    private Object extractFieldValue(IndexData entity, String sortField) {
-        return switch (sortField) {
-            case "baseDate" -> entity.getBaseDate();
-            case "closingPrice" -> entity.getClosingPrice();
-            case "marketPrice" -> entity.getMarketPrice();
-            case "highPrice" -> entity.getHighPrice();
-            case "lowPrice" -> entity.getLowPrice();
-            case "tradingQuantity" -> entity.getTradingQuantity();
-            case "tradingPrice" -> entity.getTradingPrice();
-            case "marketTotalAmount" -> entity.getMarketTotalAmount();
-            default -> entity.getId();
-        };
-    }
-
     @Transactional(readOnly = true)
     public String exportToCsv(Long indexInfoId, LocalDate startDate, LocalDate endDate,
                               String sortField, String sortDirection) {
-
         String validSortField = getValidSortField(sortField);
         String validSortDirection = getValidSortDirection(sortDirection);
-
-        // QueryDSL로 모든 데이터 조회 (cursor 없이, 무제한 조회)
         List<IndexData> dataList = indexDataRepository.findDataWithDynamicSort(
-                indexInfoId, startDate, endDate,
-                validSortField, validSortDirection, null, null, Integer.MAX_VALUE-1);
+                indexInfoId, startDate, endDate, validSortField, validSortDirection, null, null, Integer.MAX_VALUE - 1);
 
         StringBuilder csv = new StringBuilder();
         csv.append("지수분류,지수명,기준일자,소스타입,시가,종가,고가,저가,대비,등락률,거래량,거래대금,상장시가총액\n");
-
         for (IndexData data : dataList) {
             csv.append(String.format("%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s\n",
                     data.getIndexInfo().getIndexClassification(),
@@ -172,7 +122,6 @@ public class IndexDataService {
                     formatLong(data.getMarketTotalAmount())
             ));
         }
-
         return csv.toString();
     }
 
@@ -184,7 +133,6 @@ public class IndexDataService {
         LocalDate endDate = LocalDate.now();
         LocalDate startDate = calculateDate(endDate, periodType);
 
-
         List<IndexData> indexDataList = indexDataRepository.findAllByIndexInfo_IdAndBaseDateBetweenOrderByBaseDateAsc(
                 indexInfoId, startDate.minusDays(30), endDate
         );
@@ -194,30 +142,23 @@ public class IndexDataService {
                     Collections.emptyList(), Collections.emptyList(), Collections.emptyList());
         }
 
-        // 4. DTO 변환 및 이동평균선 계산 (ASC 순서로)
         List<ChartDataPoint> dataPoints = new ArrayList<>();
         List<ChartDataPoint> ma5DataPoints = new ArrayList<>();
         List<ChartDataPoint> ma20DataPoints = new ArrayList<>();
 
         for (int i = 0; i < indexDataList.size(); i++) {
             IndexData currentData = indexDataList.get(i);
-
-            // 차트에 표시될 데이터 (조회 시작일 이후)
             if (!currentData.getBaseDate().isBefore(startDate)) {
-                if(currentData.getClosingPrice() != null) {
+                if (currentData.getClosingPrice() != null) {
                     dataPoints.add(new ChartDataPoint(currentData.getBaseDate(), currentData.getClosingPrice().doubleValue()));
                 }
             }
-
-            // 5일 이동평균선 계산
             if (i >= 4) {
                 double ma5 = calculateMovingAverage(indexDataList, i, 5);
                 if (!currentData.getBaseDate().isBefore(startDate)) {
                     ma5DataPoints.add(new ChartDataPoint(currentData.getBaseDate(), ma5));
                 }
             }
-
-            // 20일 이동평균선 계산
             if (i >= 19) {
                 double ma20 = calculateMovingAverage(indexDataList, i, 20);
                 if (!currentData.getBaseDate().isBefore(startDate)) {
@@ -226,7 +167,6 @@ public class IndexDataService {
             }
         }
 
-        // 5. 응답 데이터를 DESC 순서로 정렬
         Collections.reverse(dataPoints);
         Collections.reverse(ma5DataPoints);
         Collections.reverse(ma20DataPoints);
@@ -235,61 +175,57 @@ public class IndexDataService {
                 dataPoints, ma5DataPoints, ma20DataPoints);
     }
 
-    public List<RankedIndexPerformanceDto> getRankedPerformance(
-            Long indexInfoId, PeriodType periodType, int limit) {
+    public List<RankedIndexPerformanceDto> getRankedPerformance(Long indexInfoId, PeriodType periodType, int limit) {
+        LocalDate end = indexDataRepository.findLatestBaseDate();
+        if (end == null) return List.of();
+        LocalDate start = calculateDate(end, periodType);
 
-        LocalDate latestDate = indexDataRepository.findLatestBaseDate();
-        if (latestDate == null) return List.of();
+        List<IndexData> latestList = indexDataRepository.findLatestSnapshotInRange(start, end, null);
+        if (latestList.isEmpty()) return List.of();
 
-        LocalDate cutoff = calculateDate(latestDate, periodType);
+        Map<Long, IndexData> latestById = latestList.stream()
+                .collect(Collectors.toMap(d -> d.getIndexInfo().getId(), Function.identity(), (a, b) -> a));
 
-        List<IndexData> latestList = indexDataRepository.findLatestSnapshotAtOrBefore(latestDate, null);
-        List<IndexData> pastExactList = indexDataRepository.findSnapshotAtExactDate(cutoff, null);
+        Set<Long> ids = latestById.keySet();
+        List<IndexData> earliestList = indexDataRepository.findEarliestSnapshotInRange(start, end, ids);
+        Map<Long, IndexData> earliestById = earliestList.stream()
+                .collect(Collectors.toMap(d -> d.getIndexInfo().getId(), Function.identity(), (a, b) -> a));
 
-        Map<Long, IndexData> pastById = pastExactList.stream()
-                .collect(Collectors.toMap(d -> d.getIndexInfo().getId(), Function.identity(), (a,b)->a));
-
-        List<IndexPerformanceDto> performances = new ArrayList<>();
-
-        for (IndexData cur : latestList) {
-            Long id = cur.getIndexInfo().getId();
-
+        List<IndexPerformanceDto> rows = new ArrayList<>();
+        for (Map.Entry<Long, IndexData> e : latestById.entrySet()) {
+            Long id = e.getKey();
+            IndexData cur = e.getValue();
             BigDecimal curPrice = cur.getClosingPrice();
             if (curPrice == null) continue;
 
-            IndexData past = pastById.get(id);
-            BigDecimal pastPrice = (past != null ? past.getClosingPrice() : curPrice);
-            if (pastPrice == null) pastPrice = curPrice;
+            IndexData past = earliestById.get(id);
+            BigDecimal beforePrice = (past == null || cur.getBaseDate().equals(past.getBaseDate()) || past.getClosingPrice() == null)
+                    ? curPrice
+                    : past.getClosingPrice();
 
-            BigDecimal change = curPrice.subtract(pastPrice);
-            BigDecimal rate = (pastPrice.compareTo(BigDecimal.ZERO) == 0)
+            BigDecimal versus = curPrice.subtract(beforePrice);
+            BigDecimal rate = (beforePrice.compareTo(BigDecimal.ZERO) == 0)
                     ? BigDecimal.ZERO
-                    : change.divide(pastPrice, 4, RoundingMode.HALF_UP)
-                    .multiply(BigDecimal.valueOf(100));
+                    : versus.divide(beforePrice, 4, RoundingMode.HALF_UP).multiply(BigDecimal.valueOf(100));
 
-            performances.add(IndexPerformanceDto.builder()
+            rows.add(IndexPerformanceDto.builder()
                     .indexInfoId(id)
                     .indexClassification(cur.getIndexInfo().getIndexClassification())
                     .indexName(cur.getIndexInfo().getIndexName())
-                    .versus(change)
-                    .fluctuationRate(rate)
                     .currentPrice(curPrice)
-                    .beforePrice(pastPrice)
+                    .beforePrice(beforePrice)
+                    .versus(versus)
+                    .fluctuationRate(rate)
                     .build());
         }
 
-        performances.sort(Comparator.comparing(
-                IndexPerformanceDto::getFluctuationRate,
-                Comparator.nullsLast(BigDecimal::compareTo)
-        ).reversed());
+        rows.sort(Comparator.comparing(IndexPerformanceDto::getFluctuationRate,
+                Comparator.nullsLast(BigDecimal::compareTo)).reversed());
 
         List<RankedIndexPerformanceDto> ranked = new ArrayList<>();
         int rank = 1;
-        for (IndexPerformanceDto p : performances) {
-            ranked.add(RankedIndexPerformanceDto.builder()
-                    .rank(rank++)
-                    .performance(p)
-                    .build());
+        for (IndexPerformanceDto p : rows) {
+            ranked.add(RankedIndexPerformanceDto.builder().rank(rank++).performance(p).build());
         }
 
         if (indexInfoId != null) {
@@ -297,8 +233,61 @@ public class IndexDataService {
                     .filter(r -> r.getPerformance().getIndexInfoId().equals(indexInfoId))
                     .toList();
         }
-
         return ranked.stream().limit(limit).toList();
+    }
+
+    public List<IndexPerformanceDto> getFavoritePerformance(PeriodType periodType) {
+        LocalDate end = indexDataRepository.findLatestBaseDate();
+        if (end == null) return List.of();
+        LocalDate start = calculateDate(end, periodType);
+
+        List<IndexData> latestAll = indexDataRepository.findLatestSnapshotInRange(start, end, null);
+        if (latestAll.isEmpty()) return List.of();
+
+        List<IndexData> favoriteLatest = latestAll.stream()
+                .filter(d -> d.getIndexInfo().isFavorite())
+                .toList();
+        if (favoriteLatest.isEmpty()) return List.of();
+
+        Map<Long, IndexData> latestById = favoriteLatest.stream()
+                .collect(Collectors.toMap(d -> d.getIndexInfo().getId(), Function.identity(), (a, b) -> a));
+
+        Set<Long> favIds = latestById.keySet();
+        List<IndexData> earliestList = indexDataRepository.findEarliestSnapshotInRange(start, end, favIds);
+        Map<Long, IndexData> earliestById = earliestList.stream()
+                .collect(Collectors.toMap(d -> d.getIndexInfo().getId(), Function.identity(), (a, b) -> a));
+
+        List<IndexPerformanceDto> rows = new ArrayList<>();
+        for (Map.Entry<Long, IndexData> e : latestById.entrySet()) {
+            Long id = e.getKey();
+            IndexData cur = e.getValue();
+            BigDecimal curPrice = cur.getClosingPrice();
+            if (curPrice == null) continue;
+
+            IndexData past = earliestById.get(id);
+            BigDecimal beforePrice = (past == null || cur.getBaseDate().equals(past.getBaseDate()) || past.getClosingPrice() == null)
+                    ? curPrice
+                    : past.getClosingPrice();
+
+            BigDecimal versus = curPrice.subtract(beforePrice);
+            BigDecimal rate = (beforePrice.compareTo(BigDecimal.ZERO) == 0)
+                    ? BigDecimal.ZERO
+                    : versus.divide(beforePrice, 4, RoundingMode.HALF_UP).multiply(BigDecimal.valueOf(100));
+
+            rows.add(IndexPerformanceDto.builder()
+                    .indexInfoId(id)
+                    .indexClassification(cur.getIndexInfo().getIndexClassification())
+                    .indexName(cur.getIndexInfo().getIndexName())
+                    .currentPrice(curPrice)
+                    .beforePrice(beforePrice)
+                    .versus(versus)
+                    .fluctuationRate(rate)
+                    .build());
+        }
+
+        rows.sort(Comparator.comparing(IndexPerformanceDto::getFluctuationRate,
+                Comparator.nullsLast(BigDecimal::compareTo)).reversed());
+        return rows;
     }
 
     private LocalDate calculateDate(LocalDate endDate, PeriodType periodType) {
@@ -318,6 +307,42 @@ public class IndexDataService {
                 .mapToDouble(d -> d.getClosingPrice().doubleValue())
                 .average()
                 .orElse(0.0);
+    }
+
+    private String getValidSortField(String sortField) {
+        if (sortField == null || sortField.trim().isEmpty()) {
+            return "baseDate";
+        }
+        return switch (sortField) {
+            case "baseDate", "closingPrice", "marketPrice", "highPrice", "lowPrice",
+                 "tradingQuantity", "tradingPrice", "marketTotalAmount" -> sortField;
+            default -> "baseDate";
+        };
+    }
+
+    private String getValidSortDirection(String sortDirection) {
+        return "desc".equalsIgnoreCase(sortDirection) ? "desc" : "asc";
+    }
+
+    private String generateNextCursor(IndexData entity, String sortField) {
+        String validatedField = getValidSortField(sortField);
+        Object fieldValue = extractFieldValue(entity, validatedField);
+        String json = String.format("{\"%s\":\"%s\",\"id\":%d}", validatedField, fieldValue, entity.getId());
+        return Base64.getEncoder().encodeToString(json.getBytes());
+    }
+
+    private Object extractFieldValue(IndexData entity, String sortField) {
+        return switch (sortField) {
+            case "baseDate" -> entity.getBaseDate();
+            case "closingPrice" -> entity.getClosingPrice();
+            case "marketPrice" -> entity.getMarketPrice();
+            case "highPrice" -> entity.getHighPrice();
+            case "lowPrice" -> entity.getLowPrice();
+            case "tradingQuantity" -> entity.getTradingQuantity();
+            case "tradingPrice" -> entity.getTradingPrice();
+            case "marketTotalAmount" -> entity.getMarketTotalAmount();
+            default -> entity.getId();
+        };
     }
 
     private String formatNumber(BigDecimal value) {


### PR DESCRIPTION
지수 성과 랭킹 조회 -> 일간/주간/월간에 따라서 현재날 기준으로 그 크기만큼 db에서 데이터를 가져온뒤 가장 최신날과 가장 먼 날을 기준으로 비교하여 대비/등락을 계산하고 랭킹을 추가했습니다.
db에서 하나하나 있는지 체크하면서 최신일과 일/주/월간 중에서 가장 먼곳을 저는 찾았었는데
동민님의 아이디어는 일/주/월간을 슬라이딩윈도우처럼 고정크기로 db에서 가져온뒤 서비스에서 비교하는 방법을 사용하셨거든요.
좋은 방법인것 같아서 사용했습니다.
ex) (09/15일 기준) 14일  12일데이터만 있다면 일간 은 대비/등락 0/0 , 주간,월간은 12일과 14일로 계산되도록 했습니다.

관심 지수 성과 조회는 지수 성과 랭킹 조회에서 즐겨찾기된 녀석들만 따로 파싱하고 랭킹은 추가안한 상태로 넘겨주면 되는 부분이여서
앞에 즐겨찾기 조건에 따라서 파싱하는 조건만 추가해서 구현했습니다.

-----------------------------------------------------------------------------------
용희님의 코드에서 커서페이지네이션이 정렬조건 + id 두 가지로 커서를 조정하면서 페이지를 만들었어야했는데
단일 id로만 커서를 만드셔서 정렬 이후 id하나로만 커서를 만들고 +1로 값을 찾다보니깐 정렬되었을때 아이디가 1 5 17 81 45 이런식으로 되어 있다면 45다음 46을 찾으면서 이후 2 3 4 ... 6 7 8 9 등 중간에 사라질 수 도 있는 위험성이 있더라고요
그래서 커서를 만들 때
정렬조건으로 정렬한 뒤 그다음 정렬은 id로 해서 정렬조건에 중복이 있더라도 id정렬 조건으로 한번 더 체크할수 있게 변경했습니다.

ex) 정렬기준 분류
분   류 | id | ...
KOSPI | 15 |
KOSPI | 14 |
KOSPI | 17 |
KOSPI | 9 | <-- 현재 페이지 마지막 요소라고 하면 원래라면 해당 객체 + 분류조건을 담아서 = NextCursor // NextId  = 9
KOSPI | 4 | 
KOSPI | 6 |
KOSPI | 12 |

KOSPI로 정렬 한 뒤 id로도 정렬되고 
KOSPI | 9 | <-- 시작
KOSPI | 4 | 
KOSPI | 6 |
KOSPI | 12 |

용희님 코드

분   류 | id | ...
KOSPI | 15 |
KOSPI | 14 |
KOSPI | 17 |
KOSPI | 9 | <-- 현재 페이지 마지막 요소라고 하면 용희님은 페이지의 마지막요소 전인 17까지 출력 이후 cursor의 id 다음인 9
KOSPI | 4 |
KOSPI | 6 |
KOSPI | 12 |

if (cursor != null) {
      builder.and(indexInfo.id.gt(cursor));
    }
    
  가 where절에 있어서
  4 6 인 데이터가 사리지고 정렬됨
  
KOSPI | 9 | <-- 시작
KOSPI | 12 |

그래서 id가 4 6 인 부분이 소실됩니다.

(https://everenew.tistory.com/341)
라는 곳에서 엘라스틱 서치 페이징 이라는 걸 소개하는데요.
이처럼 분류조건이 여러개이고 커서를 이용할 땐
분류조건과 다음 id(정렬이 두 개 의 조건)으로 뽑아내면 문제가 없더라고요!

그리고 다음은 지수정보 맨 아래에 총 개수를 repository.count로 전체를 다 가져와주셨는데
제가 생각하기에는 분류와 지수명으로 데이터를 검색하고 나면 그 개수를 찍어줘야하는 것 같아서
JPQL로 분류된 데이터들 개수를 세도록 바꿨습니다.